### PR TITLE
Fix bar search by supporting more varied punctuation

### DIFF
--- a/scripts/beer.coffee
+++ b/scripts/beer.coffee
@@ -10,7 +10,7 @@
 module.exports = (robot) ->
   beer_bot = 'https://beermebot.herokuapp.com'
 
-  robot.respond /what's on tap at ([^\?]*)\??/i, (msg) ->
+  robot.respond /what['’]?s on tap at ([^\?]*)\??/i, (msg) ->
     search_for(msg, 'bars')
 
   robot.respond /where is (.*) on tap\??/i, (msg) ->


### PR DESCRIPTION
PhillyDev slack uses a different character for ' than what I get on the command line, so bar search has not been working.  This adds support for both characters (and for the typo "whats"), so that bar search actually works in Slack.
